### PR TITLE
Add Frontier fork support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN get_fork_build_url() { \
             "goob") \
                 BUILD_LIST_URL="https://cdn.goobstation.com/fork/GoobLRP" \
                 ;; \
+	    "frontier") \
+                BUILD_LIST_URL="https://cdn.frontierstation14.com/fork/Frontier" \
+		;; \
             *) \
                 BUILD_LIST_URL="https://wizards.cdn.spacestation14.com/fork/wizards" \
                 ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir /ss14 && \
 
 
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0
+FROM mcr.microsoft.com/dotnet/runtime:9.0
 
 RUN adduser --disabled-password --home /home/ss14 --shell /bin/bash ss14
 COPY --from=fetch /ss14 /home/ss14


### PR DESCRIPTION
Also updates Dotnet runtime to 9.0 because of
```
You must install or update .NET to run this application.

App: /home/ss14/Robust.Server
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '9.0.0' (x64)
.NET location: /usr/share/dotnet

The following frameworks were found:
  8.0.13 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```